### PR TITLE
Add README.md and CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,129 @@
+# Contributing to Sigil (CSSL)
+
+## Overview
+
+The Sigil compiler lives in `compiler-rs/` — a Cargo workspace of 32 crates written in Rust (MSRV 1.75). This is the **stage0 bootstrap compiler**: Rust-hosted, throwaway once the language self-hosts.
+
+## Crate map
+
+### Frontend
+
+| Crate | Purpose |
+|-------|---------|
+| `cssl-lex` | Dual-surface lexer (logos + hand-rolled CSLv3-native path) |
+| `cssl-parse` | Recursive-descent parser — no parser-combinator framework |
+| `cssl-ast` | CST + source-preservation + `Diagnostic` type |
+
+### Type system
+
+| Crate | Purpose |
+|-------|---------|
+| `cssl-hir` | Typed HIR — Hindley-Milner inference + effect-row unification |
+| `cssl-caps` | Pony-6 capability checker (`iso/trn/ref/val/box/tag`) |
+| `cssl-ifc` | Jif-DLM information-flow labels; encodes PRIME_DIRECTIVE structurally |
+| `cssl-effects` | 28+ effect registry + sub-effect discipline + banned-composition checker |
+
+### Transformation passes
+
+| Crate | Purpose |
+|-------|---------|
+| `cssl-autodiff` | Source-to-source AD — 19 primitives, `fwd` + `bwd` on MIR |
+| `cssl-jets` | `Jet<T,N>` higher-order AD for inverse-rendering / inverse-fluids |
+| `cssl-smt` | Z3/CVC5/KLEE drivers + SMT-LIB emission + obligation discharge |
+| `cssl-staging` | `@staged` comptime specializer + `#run` evaluation |
+| `cssl-futamura` | Futamura P1/P2/P3 partial-evaluation infrastructure |
+| `cssl-macros` | Racket-hygienic macro system (unified with staging) |
+
+### IR
+
+| Crate | Purpose |
+|-------|---------|
+| `cssl-mir` | Structured mid-level IR (MLIR dialect; control-flow + SSA) |
+| `cssl-lir` | Low-level IR + target orchestration |
+| `cssl-mlir-bridge` | melior FFI for MLIR dialect emissions |
+
+### Codegen
+
+| Crate | Purpose |
+|-------|---------|
+| `cssl-cgen-cpu-cranelift` | CPU codegen via Cranelift 0.115 — no LLVM |
+| `cssl-cgen-gpu-spirv` | SPIR-V emitter via rspirv |
+| `cssl-cgen-gpu-dxil` | DXIL emitter |
+| `cssl-cgen-gpu-msl` | MSL emitter |
+| `cssl-cgen-gpu-wgsl` | WGSL emitter |
+
+### Host runtimes
+
+| Crate | Purpose |
+|-------|---------|
+| `cssl-host-vulkan` | Vulkan 1.4 via ash |
+| `cssl-host-level-zero` | Intel Level-Zero + sysman |
+| `cssl-host-d3d12` | D3D12 via windows-rs |
+| `cssl-host-metal` | Metal (macOS, cfg-gated) |
+| `cssl-host-webgpu` | WebGPU via wgpu |
+
+### Observability & testing
+
+| Crate | Purpose |
+|-------|---------|
+| `cssl-telemetry` | R18 ring-buffer + OTLP + signed audit chain |
+| `cssl-testing` | Oracle-modes dispatcher (property / differential / metamorphic / fuzz / replay) |
+| `cssl-persist` | Orthogonal persistence image + schema migration |
+| `cssl-rt` | Runtime library |
+| `csslc` | Compiler binary entry point |
+
+## Good entry points
+
+If you're new and want to make a real contribution, start here:
+
+- **`cssl-lex`** — self-contained, well-tested, good surface-area for the dual-syntax design
+- **`cssl-effects`** — data-heavy, logic-light; good for adding effects or improving documentation
+- **`cssl-smt`** — SMT-LIB emission improvements are isolated and high-value
+- **`cssl-cgen-gpu-spirv`** — SPIR-V emission is a well-scoped domain with clear correctness criteria
+
+For larger contributions, read [`DECISIONS.md`](DECISIONS.md) for prior architectural decisions and `specs/` for the authoritative design.
+
+## Running tests
+
+```bash
+cd compiler-rs
+
+# All 1600+ tests
+cargo test --workspace
+
+# Single crate
+cargo test -p cssl-lex
+cargo test -p cssl-parse
+cargo test -p cssl-autodiff
+
+# Clippy (must be clean)
+cargo clippy --workspace -- -D warnings
+```
+
+## Conventions
+
+**Spec authority** — if your code diverges from `specs/`, the spec wins. File the code as a bug, not the spec.
+
+**Unsafe** — all non-FFI crates use `#![forbid(unsafe_code)]`. Don't add `unsafe` to `cssl-lex`, `cssl-parse`, `cssl-ast`, `cssl-hir`, `cssl-effects`, `cssl-autodiff`, `cssl-mir`, `cssl-staging`, or `csslc`. FFI crates (`cssl-host-*`, `cssl-smt`, `cssl-mlir-bridge`) opt-in per-file.
+
+**Clippy** — the workspace runs pedantic + nursery lint sets. New code must pass `cargo clippy -- -D warnings`. Existing allowances in `Cargo.toml` are scaffold-phase; don't add new ones without discussion.
+
+**Comments** — only write comments when the *why* is non-obvious (hidden constraint, spec-deviation workaround, subtle invariant). Don't comment what the code does; use descriptive identifiers instead.
+
+**Decision log** — significant design decisions go in `DECISIONS.md`:
+```
+T<N>-D<M> : <decision-title> — <rationale>
+```
+
+## Submitting changes
+
+1. Fork the repo and create a branch from `main`.
+2. Make your change and ensure `cargo test --workspace` passes.
+3. Ensure `cargo clippy --workspace -- -D warnings` is clean.
+4. Open a pull request against `main` with a concise description of what and why.
+
+If your change touches the type system, effect registry, autodiff passes, or IFC, link to the relevant spec section in `specs/`.
+
+## License
+
+By contributing you agree your work is licensed Apache-2.0 OR MIT, matching the workspace.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,151 @@
+# Sigil
+
+**Hardware-first systems language with algebraic effects, autodiff, SMT verification, and multi-GPU backends.**
+
+No LLVM. Cranelift JIT. Consent encoded structurally.
+
+---
+
+## What is Sigil?
+
+Sigil (formally *CSSL — Caveman-Sigil-Substrate-Language*) is a compiled systems language for programs that span CPU, GPU, and real-time hardware. Effect tracking, automatic differentiation, formal verification, and information-flow control are core language features — not library add-ons.
+
+## Six non-negotiable features
+
+| | Feature | Description |
+|--|---------|-------------|
+| F1 | **Autodiff** | Source-to-source AD on MIR. `Jet<T,N>` higher-order. No LLVM dependency. |
+| F2 | **Refinement Types** | SMT-backed `{v:T \| P(v)}`, Lipschitz bounds, control-flow narrowing. |
+| F3 | **Effect System** | Row-polymorphic effect rows (Koka semantics). 28+ built-in effects. |
+| F4 | **Staged Computation** | `@staged` + `#run` comptime. Futamura P1/P2/P3 self-applicable. |
+| F5 | **Information Flow Control** | Jif-style DLM labels + declassification. Structurally enforced. |
+| F6 | **Observability** | R18 telemetry, signed audit chain, oracle test modes. |
+
+## Syntax
+
+```sigil
+// Differentiable SDF with Lipschitz bound — compiler-checked.
+@differentiable
+@lipschitz(k = 1.0)
+fn sphere_sdf(p: vec3, r: f32'pos) -> f32 {
+    length(p) - r
+}
+
+// Real-time audio callback — effect row is part of the type.
+// Calling this from a GPU kernel is a compile error.
+fn audio_callback<G: AudioDSPGraph>(buf: &mut [f32])
+    / {CPU, SIMD256, NoAlloc, Deadline<1ms>, Realtime<Crit>, Audit<"audio-callback">}
+{
+    process_block(&mut G::default(), buf)
+}
+
+// Autodiff: backward-pass gradient of sphere_sdf, bit-exact vs analytic.
+let normal = bwd_diff(sphere_sdf)(p, r).d_p.normalize();
+```
+
+Effect rows (`/ {CPU, SIMD256, ...}`) are checked and enforced by the compiler — they participate in type inference and unification.
+
+## Architecture
+
+**32 Rust crates** in a Cargo workspace. Stage0 bootstrap — Rust-hosted, throwaway once stage1 self-hosts.
+
+```
+Frontend
+  cssl-lex          dual-surface lexer (logos + hand-rolled)
+  cssl-parse        recursive-descent parser
+  cssl-ast          CST + source-preservation + Diagnostic
+
+Type System
+  cssl-hir          typed HIR — Hindley-Milner + effect-row unification
+  cssl-caps         Pony-6 capability checker (iso/trn/ref/val/box/tag)
+  cssl-ifc          Jif-DLM information-flow labels (structurally encoded)
+  cssl-effects      28+ effect registry + discipline checker
+
+Transformation
+  cssl-autodiff     source-to-source AD (19 primitives, fwd + bwd)
+  cssl-jets         Jet<T,N> higher-order AD
+  cssl-smt          Z3/CVC5/KLEE drivers + SMT-LIB emission
+  cssl-staging      @staged comptime specializer
+  cssl-futamura     Futamura P1/P2/P3 partial evaluation
+  cssl-macros       Racket-hygienic macro system
+
+IR
+  cssl-mir          structured mid-level IR (MLIR dialect)
+  cssl-lir          low-level IR + target orchestration
+  cssl-mlir-bridge  melior FFI
+
+Codegen (No LLVM)
+  cssl-cgen-cpu-cranelift     CPU via Cranelift 0.115
+  cssl-cgen-gpu-spirv         SPIR-V emitter
+  cssl-cgen-gpu-dxil          DXIL emitter
+  cssl-cgen-gpu-msl           MSL emitter
+  cssl-cgen-gpu-wgsl          WGSL emitter
+
+Host Runtimes
+  cssl-host-vulkan            Vulkan 1.4
+  cssl-host-level-zero        Intel Level-Zero + sysman
+  cssl-host-d3d12             Direct3D 12
+  cssl-host-metal             Metal (macOS)
+  cssl-host-webgpu            WebGPU (wgpu)
+
+Observability & Testing
+  cssl-telemetry              R18 ring-buffer + OTLP + signed audit chain
+  cssl-testing                oracle test modes dispatcher
+  cssl-persist                orthogonal persistence + schema migration
+  cssl-rt                     runtime library
+  csslc                       compiler binary
+```
+
+## Effect system
+
+28+ built-in effects cover resource constraints, timing, determinism, hardware backends, power, and audit:
+
+```
+Timing      Deadline<16ms>  Realtime<Crit>
+Hardware    CPU  GPU  XMX  RT  SIMD256  NUMA<node>  Cache<L1>
+Backends    Backend<Vulkan>  Backend<D3D12>  Backend<Metal>  Backend<WebGPU>
+Alloc       NoAlloc  NoUnbounded  Region<'r>
+Determinism PureDet  DetRNG  Reversible
+Power       Power<15w>  Thermal<85c>
+Audit       Audit<"domain">  Sensitive<privacy>  Verify<Z3>
+```
+
+Zero runtime overhead — compiled to evidence-records via Xie+Leijen ICFP'21 semantics.
+
+## No LLVM
+
+The CPU backend targets [Cranelift](https://cranelift.dev/) directly. GPU output goes SPIR-V → Vulkan/D3D12/WebGPU or MSL for Metal. The full compiler builds with a plain `cargo build --release`.
+
+## Status
+
+Stage0 (Rust-hosted bootstrap) — all six features implemented at minimum-viable depth. 1600+ tests passing.
+
+Stage1 (self-hosted) is the next milestone. See [`stage1/README.csl`](stage1/README.csl) for the P1–P10 roadmap.
+
+## Build from source
+
+Requires Rust 1.75+. No other system dependencies.
+
+```bash
+git clone https://github.com/Apocky/CSSL3
+cd CSSL3/compiler-rs
+cargo build --release
+# binary: target/release/csslc
+```
+
+Or grab the pre-built Windows binary from [Releases](https://github.com/Apocky/CSSL3/releases).
+
+## Documentation
+
+- [`specs/`](specs/) — complete formal design in CSLv3 notation (20 documents)
+- [`DECISIONS.md`](DECISIONS.md) — every architectural decision, T1-D1 through present
+- [`PRIME_DIRECTIVE.md`](PRIME_DIRECTIVE.md) — foundational consent axiom, encoded for humans, AI agents, and compilers
+- [`examples/`](examples/) — annotated Sigil programs (Vulkan triangle, SDF autodiff, real-time audio)
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md). Good first issues are labeled in the [issue tracker](https://github.com/Apocky/CSSL3/issues?q=label%3A%22good+first+issue%22).
+
+## License
+
+Apache-2.0 OR MIT


### PR DESCRIPTION
## Summary

- **README.md** — public landing page: six core language features, 32-crate architecture diagram, effect system overview, GPU backends, Cranelift CPU backend, build instructions, links to specs and examples
- **CONTRIBUTING.md** — full crate map (32 crates in tables by layer), good entry points for newcomers, test commands, coding conventions (spec authority, unsafe policy, clippy discipline, decision log format)

## Why

The repo had no README, making it invisible on GitHub. These two files are the minimum for discoverability and contributor onboarding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)