### PR TITLE
refactor(hir): audit #[allow(dead_code)] stubs in cssl-hir

### DIFF
--- a/compiler-rs/crates/cssl-hir/src/cap_check.rs
+++ b/compiler-rs/crates/cssl-hir/src/cap_check.rs
@@ -134,7 +134,14 @@ impl CapCtx {
         }
     }
 
-    #[allow(dead_code)] // reserved for T3.4-phase-2.5 expression walk
+    // Reserved for the deferred T3.4-phase-2.5 body-walk slice of cap_check.
+    // The signature-level minimum-viable check landed in DECISIONS.md § T5-D3
+    // (Cap-check pass sig-level only for stage-0 ; full expr walk deferred),
+    // which explicitly defers "full linear-use tracking through every
+    // expression" + "handler-one-shot enforcement" to T3.4-phase-2.5. This
+    // helper will be wired in when that slice lands; until then, cargo
+    // -D warnings needs the allow.
+    #[allow(dead_code)] // T5-D3: wired in at T3.4-phase-2.5
     fn emit(&mut self, message: impl Into<String>, span: Span) {
         self.diagnostics
             .push(Diagnostic::error(message).with_span(span));
@@ -228,7 +235,10 @@ impl CapCtx {
         }
     }
 
-    #[allow(dead_code)] // reserved for T3.4-phase-2.5 expression walk
+    // See `emit` above for the DECISIONS.md § T5-D3 tracking note -- matrix() is
+    // the AliasMatrix accessor the deferred T3.4-phase-2.5 body-walk needs to
+    // run `AliasMatrix::can_pass_through`/`param_subtype_check` at call sites.
+    #[allow(dead_code)] // T5-D3: wired in at T3.4-phase-2.5
     fn matrix(&self) -> &AliasMatrix {
         &self.matrix
     }

--- a/compiler-rs/crates/cssl-hir/src/lower.rs
+++ b/compiler-rs/crates/cssl-hir/src/lower.rs
@@ -18,7 +18,7 @@
 //!     `HirExprKind::Compound` with the operator-class preserved.
 
 use cssl_ast::cst;
-use cssl_ast::{DiagnosticBag, Ident, Module as CstModule, SourceFile, Span};
+use cssl_ast::{DiagnosticBag, Ident, Module as CstModule, SourceFile};
 
 use crate::arena::{DefId, HirArena, HirId};
 use crate::attr::{HirAttr, HirAttrArg, HirAttrKind};
@@ -1267,9 +1267,6 @@ fn resolve_struct_body(b: &mut HirStructBody, scope: &ScopeMap) {
     }
 }
 
-/// Hide the empty Span+SourceFile re-export so the `Span` import doesn't show as unused.
-#[allow(dead_code)]
-const fn _span_referenced(_: Span) {}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
## Summary

Closes #2. Audits the three `#[allow(dead_code)]` items in cssl-hir against "has the T3.4-phase-2.5 work landed or is it still pending" per the issue's decision tree, and applies the follow-up the issue prescribes for each case.

## Outcome per item

**1. `compiler-rs/crates/cssl-hir/src/cap_check.rs:137` — `fn emit(..., span: Span)`**

Pending. DECISIONS.md § T5-D3 (Cap-check pass sig-level only for stage-0; full expr walk deferred) explicitly defers "full linear-use tracking through every expression" and "handler-one-shot enforcement" to T3.4-phase-2.5. The Session-1 STATUS line lists T3.4-phase-2-refinement / T3.4-phase-3-AD-legality / T3.4-phase-3-IFC as ✓, but *not* T3.4-phase-2.5.

Per the issue: "If the work is still pending: add a tracking comment with the DECISIONS.md entry it's waiting on." Upgraded the bare `// reserved for T3.4-phase-2.5 expression walk` to an explicit pointer to § T5-D3 so the next person opening cap_check.rs lands on the actual DECISIONS entry instead of having to grep for T5-D3 themselves. `#[allow(dead_code)]` kept.

**2. `compiler-rs/crates/cssl-hir/src/cap_check.rs:231` — `fn matrix(...) -> &AliasMatrix`**

Same dependency as (1). `matrix()` is the accessor the deferred body walk needs to call `AliasMatrix::can_pass_through` / `param_subtype_check` at call sites (per § T5-D3's "ready for use when T3.4-phase-2.5 walks call-args" note). Same tracker comment upgrade.

**3. `compiler-rs/crates/cssl-hir/src/lower.rs:1271` — `const fn _span_referenced(_: Span) {}`**

Genuinely dead. The stub exists only so `Span` in the `use cssl_ast::{...}` line doesn't trip `-D warnings`. Grepping `lower.rs` for `Span` returns exactly three hits: the import on line 21, the stub's `///` comment on line 1270, and the stub's signature on line 1272. Nothing outside the stub uses `Span`.

Per the issue's guidance: "If the work is complete and the function is genuinely unused: remove it, or wire it up if it was meant to be called." Removed both the stub and `Span` from the import. `SourceFile` stays in the import — it IS used at lines 49, 56, and 919.

## Verification

```
$ cargo build --workspace
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 14.62s

$ cargo test -p cssl-hir
test result: ok. 195 passed; 0 failed; 0 ignored
```

Clean compile across the workspace (no new `unused_imports` warning from the `Span` removal), all 195 cssl-hir tests pass.

## Scope note

The issue lists three items. This PR addresses exactly those three — no opportunistic removal of other `#[allow(dead_code)]`s elsewhere in cssl-hir. If the project wants a broader sweep later, it's a follow-up issue's scope.

Closes #2

---

This contribution was developed with AI assistance (Claude Code).
